### PR TITLE
Fix color corruption in Windows

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -3,7 +3,7 @@
 	"tasks": [
 		{
 			"type": "shell",
-			"command": "cargo build",
+			"command": "CARGO_ASC=true CARGO_MSG_LIMIT=1 cargo lcheck",
 			"problemMatcher": [
 				"$rustc"
 			],
@@ -13,13 +13,13 @@
 			},
 			"presentation": {
 				"echo": true,
-				"reveal": "silent",
+				"reveal": "always",
 				"focus": false,
 				"panel": "shared",
 				"showReuseMessage": true,
 				"clear": true
 			},
-			"label": "cargo cargo build"
+			"label": "cargo check"
 		}
 	]
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -3,7 +3,7 @@
 	"tasks": [
 		{
 			"type": "shell",
-			"command": "CARGO_ASC=true CARGO_MSG_LIMIT=1 cargo lcheck",
+			"command": "cargo build",
 			"problemMatcher": [
 				"$rustc"
 			],
@@ -13,13 +13,13 @@
 			},
 			"presentation": {
 				"echo": true,
-				"reveal": "always",
+				"reveal": "silent",
 				"focus": false,
 				"panel": "shared",
 				"showReuseMessage": true,
 				"clear": true
 			},
-			"label": "cargo check"
+			"label": "cargo cargo build"
 		}
 	]
 }

--- a/src/repo.rs
+++ b/src/repo.rs
@@ -330,6 +330,7 @@ impl Repository {
             .current_dir(self.path())
             .stdout(Stdio::piped())
             .stderr(Stdio::piped())
+            .stdin(Stdio::null())
             .spawn()?;
         let output = child.wait_with_output()?;
         if !output.status.success() {


### PR DESCRIPTION
Git seems to corrupt the terminal colors when the terminal's stdin
is given to it