### PR TITLE
Retry branch deletion when we encounter vscode configuration markers-related failures

### DIFF
--- a/src/repo.rs
+++ b/src/repo.rs
@@ -1,3 +1,4 @@
+use crate::utils::delete_branch_with_retry;
 use crate::utils::ObjectKind;
 use crate::utils::PathExt;
 
@@ -57,7 +58,8 @@ impl Repository {
     }
 
     pub fn delete_branch_name(&self, branch_name: &str) -> Result<()> {
-        Ok(self.find_branch(branch_name)?.delete()?)
+        let mut branch = self.find_branch(branch_name)?;
+        delete_branch_with_retry(&mut branch)
     }
 
     pub fn delete_tag(&self, tag_name: &str) -> Result<()> {
@@ -139,13 +141,12 @@ impl Repository {
                         info!("Branch {} is not merged into local develop, but is merged to remote develop. Deleting...", name);
                         if current_branch_name == name {
                             info!(
-                                "Branch {} is the current branch, switching to {}...",
-                                current_branch_name,
+                                "Branch {current_branch_name} is the current branch, switching to {}...",
                                 develop_branch.name()?.unwrap()
                             );
                             self.switch_to_branch(&develop_branch)?;
                         }
-                        branch.delete()?;
+                        delete_branch_with_retry(&mut branch)?;
                     }
                 }
             }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -2,11 +2,13 @@ use crate::{commands::BumpKind, pargit::Pargit};
 
 use anyhow::{bail, Result};
 use dialoguer::theme::{ColorfulTheme, SimpleTheme, Theme};
-use log::debug;
+use git2::{Branch, ErrorClass};
+use log::{debug, warn};
 use semver::Version;
 use std::{
     path::Path,
     process::{Output, Stdio},
+    time::Duration,
 };
 use strum_macros::EnumIter;
 
@@ -70,6 +72,34 @@ pub fn get_color_theme() -> Box<dyn Theme> {
 
 pub fn can_ask_questions() -> bool {
     std::env::var("PARGIT_NON_INTERACTIVE").as_deref() != Ok("1")
+}
+
+const MAX_DELETE_RETRIES: usize = 3;
+const RETRY_SLEEP_DURATION: Duration = Duration::from_millis(100);
+
+fn should_retry_delete_error(error: &git2::Error) -> bool {
+    matches!(error.class(), ErrorClass::Config)
+}
+
+pub fn delete_branch_with_retry(branch: &mut Branch) -> Result<()> {
+    let mut attempts = 0;
+
+    while let Err(e) = branch.delete() {
+        attempts += 1;
+        if attempts >= MAX_DELETE_RETRIES {
+            return Err(e.into());
+        }
+
+        if should_retry_delete_error(&e) {
+            warn!(
+                        "Branch deletion failed (attempt {attempts}/{MAX_DELETE_RETRIES}): {e}. Retrying...",
+                    );
+            std::thread::sleep(RETRY_SLEEP_DURATION);
+            continue;
+        }
+        return Err(e.into());
+    }
+    Ok(())
 }
 
 struct ExitStackItem<'a> {


### PR DESCRIPTION
VSCode plants custom configuration paths, which interfere with automated branch deletion if it is open in the background. This change makes pargit retry on these cases, avoiding unnecessary failures